### PR TITLE
ci(fedora-40): Added fedora 40 into molecule targets

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -31,6 +31,8 @@ jobs:
           ]
         continueOnError: [false]
         include:
+          - distro: rubemlrm/fedora-ansible:40
+            continueOnError: true
           - distro: rubemlrm/fedora-ansible:rawhide
             continueOnError: true
     steps:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         distro:
           [
-            "rubemlrm/fedora-ansible:38",
             "rubemlrm/fedora-ansible:39",
           ]
         continueOnError: [false]

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,13 @@ help: # Show this help.
 # Lint all files with ansible-lint
 lint:
 	molecule lint
+
+.PHONY: install-deps
+# Install galaxy dependencies
+install-deps:
+	ansible-galaxy install -r requirements.yml
+
+.PHONY: run-playbook
+# Run playbook for workstation
+run-playbook:
+	ansible-playbook setup.yml -i inventory.yml --ask-become-pass --limit "DojoDesktop"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 # (/usr/bin/ansible will use current user as default)
 host_key_checking = False
-collections_paths = ./collections
+#collections_paths = ./collections
 become = true
 [ssh_connection]
 pipelining=True

--- a/molecule/default/roles_test/golang_test.yml
+++ b/molecule/default/roles_test/golang_test.yml
@@ -14,7 +14,7 @@
       - go_pkg_status
 - name: "Golang test - check package status"
   ansible.builtin.file:
-    path: "{{ home_dir }}go/bin/lazygit"
+    path: "{{ home_dir }}go/bin/mockery"
     state: "file"
   check_mode: yes
   register: pkg_status

--- a/roles/cli/defaults/main.yaml
+++ b/roles/cli/defaults/main.yaml
@@ -37,7 +37,6 @@ common_cli_base_packages:
   - libselinux-python3
   - unrar
   - openssl
-  - lazygit
 
 common_cli_font_packages:
   - adobe-source-code-pro-fonts
@@ -45,9 +44,7 @@ common_cli_font_packages:
   - fontawesome-fonts
   - jetbrains-mono-fonts
 
-common_cli_copr_repos:
-  - atim/lazygit
-
+common_cli_copr_repos: []
 
 common_cli_rpm_repos:
   - "http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/roles/cli/defaults/main.yaml
+++ b/roles/cli/defaults/main.yaml
@@ -37,6 +37,7 @@ common_cli_base_packages:
   - libselinux-python3
   - unrar
   - openssl
+  - lazygit
 
 common_cli_font_packages:
   - adobe-source-code-pro-fonts
@@ -44,7 +45,8 @@ common_cli_font_packages:
   - fontawesome-fonts
   - jetbrains-mono-fonts
 
-common_cli_copr_repos: []
+common_cli_copr_repos:
+  - atim/lazygit
 
 common_cli_rpm_repos:
   - "http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/roles/desktop/defaults/main.yaml
+++ b/roles/desktop/defaults/main.yaml
@@ -11,6 +11,7 @@ common_desktop_flatpak_packages:
   - com.yubico.yubioath
   - com.github.iwalton3.jellyfin-media-player
   - net.cozic.joplin_desktop
+  - org.jellyfin.JellyfinServer
 
 common_desktop_snap_packages: {}
 

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -17,9 +17,9 @@
       register: stat_results
       with_items:
         - bin: lazygit
-          repo: github.com/jesseduffield/lazygit@latest
+          repo: github.com/jesseduffield/lazygit@v0.41.0
         - bin: helm-docs
-          repo: github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+          repo: github.com/norwoodj/helm-docs/cmd/helm-docs@v1.13.1
         - bin: golangci-lint
           repo: github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
         - bin: goose

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -16,10 +16,6 @@
         path: "{{ home_dir }}go/bin/{{ item.bin }}"
       register: stat_results
       with_items:
-        - bin: lazygit
-          repo: github.com/jesseduffield/lazygit@v0.41.0
-        - bin: helm-docs
-          repo: github.com/norwoodj/helm-docs/cmd/helm-docs@v1.13.1
         - bin: golangci-lint
           repo: github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
         - bin: goose


### PR DESCRIPTION
Added fedora 40 as molecule target to validate the playbook against the next stable version

# Pull Request

## Type

- [ ] fix: a PR thats fixes a bug.
- [x] feat: a PR thats adds new functionality.
- [ ] docs: a PR thats changes documentation.
- [ ] test: a PR thats adds tests.
- [ ] perf: a PR thats improves performance.
- [ ] chore: a non-specfic PR.

## Pull Request Description

**Close issue  [ISSUE-NUMBER](https://github.com/Rubemlrm/buildfiles/issues/ISSUE-NUMBER)**

## Additonal Notes
